### PR TITLE
Add a command to generate initial config.

### DIFF
--- a/exe/argonaut
+++ b/exe/argonaut
@@ -18,6 +18,10 @@ begin
   OptionParser.new do |opts|
     opts.banner = "Usage: argonaut [options]"
 
+    opts.on("--init", "Initialize an argonaut installation by creates a default argonaut.yml file") do |c|
+      options[:action] = 'init_configuration'
+    end
+
     opts.on("-T", "--teams", "Show all teams") do |c|
       options[:action] = 'show_teams'
     end

--- a/lib/argonaut.rb
+++ b/lib/argonaut.rb
@@ -33,6 +33,12 @@ module Argonaut
     when 'list_reservations'
       data = interface.list_reservations.fetch('data', nil)
       print_reservations_list(data)
+    when 'init_configuration'
+      if interface.initialize_configuration_file
+        puts "'#{SETTINGS_FILE}' initialized. Modify to update your api token"
+      else
+        puts "'#{SETTINGS_FILE}' already exists. No initialization needed"
+      end
     end
   end
 

--- a/lib/argonaut/cli.rb
+++ b/lib/argonaut/cli.rb
@@ -42,5 +42,27 @@ module Argonaut
       data = { application_name: app_name }
       @gateway.fetch(path: "find_application", data: data)
     end
+
+    def initialize_configuration_file
+      return false if File.exist? Argonaut::Constants::SETTINGS_FILE
+
+      File.open( Argonaut::Constants::SETTINGS_FILE, "w" ) do |f|
+        f.write %q(
+# The only required fields needed by the gem to function are api_token and url_root
+
+api_token: YOUR_TOKEN
+url_root: https://theargonaut-api.herokuapp.com
+
+# Below are the optional settings to customize output
+
+options:
+  colorize_rows: true
+  time_format: '%d %b %Y %l:%M %p'
+  high_contrast_colors: true
+)
+      end
+      true
+    end
+
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -84,5 +84,23 @@ describe Argonaut::Cli do
       expect { cli.clear_reservations }.to_not raise_error
       expect(s).to have_been_requested
     end
+
+    it 'config exists: does not initialize configuration' do
+      expect(File).to receive(:exist?).and_return(true)
+      expect(File).to_not receive(:open)
+
+      expect(cli.initialize_configuration_file).to be_falsey
+    end
+
+    it 'config missing: initializes configuration' do
+      expect(File).to receive(:exist?).and_return(false)
+      mock_file = StringIO.new
+      expect(File).to receive(:open).with(Argonaut::Constants::SETTINGS_FILE, 'w').and_yield(mock_file)
+
+      expect(cli.initialize_configuration_file).to equal(true)
+      ['api_token: YOUR_TOKEN', 'url_root:'].each do |str|
+        expect(mock_file.string).to include(str)
+      end
+    end
   end
 end


### PR DESCRIPTION
Starting from "Copy this from the README into a file on disk" seems a bit prone to error.

Add a command that creates the raw .argonaut.yml file. Still expected to update the file afterwards.